### PR TITLE
Add tensor-parallel MLP correctness test with manual BF16 reduction

### DIFF
--- a/app/python/gemm_manual.py
+++ b/app/python/gemm_manual.py
@@ -1,0 +1,246 @@
+import argparse
+
+import torch
+import torch.nn.functional as F
+
+from dae.launcher import *
+from dae.schedule import Schedule, ListSchedule
+from dae.util import dae_app, tensor_diff
+from manual_sum import manual_reduction
+
+class ManualGemm(Schedule):
+    def __init__(self, Atom, MNK, tmas, MNK_base, num_k_folds):
+        super().__init__()
+        self.Atom = Atom
+        self.MNK = MNK
+        self.tmas = tmas
+        self.MNK_base = MNK_base
+        self.num_k_folds = num_k_folds
+
+    def schedule(self, sm: int):
+        if sm < 0:
+            return []
+
+        BaseM, BaseN, BaseK = self.MNK_base
+        TileM, TileN, TileK = self.Atom.MNK
+        loadA, loadB, reduceC = self.tmas
+        M, N, K = self.MNK
+
+        instructions = []
+
+        m_tiles = M // TileM
+        n_tiles = N // TileN
+
+        # Distribute output row tiles across SMs --> each SM handles every num_sms-th M tile
+        for m_tile_id in range(sm, m_tiles, self.num_sms):
+            m = BaseM + m_tile_id * TileM
+
+            # For the current row tile sweep across all output column tiles.
+            for n_tile_id in range(n_tiles):
+                n = BaseN + n_tile_id * TileN
+
+                # Accumulate this output tile by reducing over K in TileK-sized chunks
+                instructions.append(self.Atom(self.num_k_folds))
+
+                for fold in range(self.num_k_folds):
+                    k = BaseK + fold * TileK
+                    instructions.append(loadB.cord(n, k))
+                    instructions.append(loadA.cord(m, k))
+
+                instructions.append(reduceC.cord(m, n))
+
+        return instructions
+
+
+gpu = torch.device("cuda")
+torch.manual_seed(0)
+dtype = torch.bfloat16
+
+Atom = Gemm_M64N64K64
+TileM, TileN, TileK = Atom.MNK
+
+# MLP dimensions
+M = TileM * 128
+N = TileN * 8
+num_k_folds = 16
+K = TileK * num_k_folds
+num_sms = 128
+
+tp_size = 2
+n_chunk_tiles = 4
+
+assert K % TileK == 0
+assert M % TileM == 0
+assert N % TileN == 0
+assert N % TileK == 0
+
+# First GEMM tensors:
+#
+# matC = matA @ matB.t()
+# matA: M x K
+# matB: N x K
+# matC: M x N
+
+matA = torch.rand(M, K, dtype=dtype, device=gpu) - 0.5
+matB = torch.rand(N, K, dtype=dtype, device=gpu) - 0.5
+matC = torch.zeros(M, N, dtype=dtype, device=gpu)
+
+# First GEMM:
+# N-split / column-parallel
+#
+# Computes:
+# matC = matA @ matB.t()
+
+n_tiles = N // TileN
+
+assert n_tiles % tp_size == 0
+n_tiles_per_rank = n_tiles // tp_size
+
+matC.zero_()
+torch.cuda.synchronize()
+
+for tp_rank in range(tp_size): # Pretending here that the work is split across multiple “parallel workers” or “virtual GPUs.” Each one is a rank.
+    rank_n_start_tile = tp_rank * n_tiles_per_rank # Split the work across ranks
+    rank_n_end_tile = rank_n_start_tile + n_tiles_per_rank # Split the work across ranks
+
+    for n_base_tile in range(rank_n_start_tile, rank_n_end_tile, n_chunk_tiles):
+        cur_n_tiles = min(n_chunk_tiles, rank_n_end_tile - n_base_tile)
+        N_chunk = cur_n_tiles * TileN
+        BaseN = n_base_tile * TileN
+
+        dae = Launcher(num_sms, device=gpu)
+
+        loadA = TmaTensor(dae, matA).wgmma_load(TileM, TileK, Major.K)
+        loadB = TmaTensor(dae, matB).wgmma_load(TileN, TileK * Atom.n_batch, Major.K)
+        reduceC = TmaTensor(dae, matC).wgmma("reduce", TileM, TileN, Major.K)
+
+        gemm = ManualGemm(
+            Atom,
+            MNK=(M, N_chunk, K),
+            tmas=(loadA, loadB, reduceC),
+            MNK_base=(0, BaseN, 0),
+            num_k_folds=num_k_folds,
+        ).place(num_sms, base_sm=0)
+
+        dae.i(
+            gemm,
+            TerminateC(),
+            TerminateM(),
+        )
+
+        dae_app(dae)
+
+torch.cuda.synchronize()
+
+hidden_ref = matA @ matB.t()
+hidden_res = matC
+
+tensor_diff("first_gemm_hidden", hidden_ref, hidden_res)
+
+# Activation:
+# matSilu = silu(matC)
+
+matSilu = F.silu(matC).contiguous()
+matSilu_ref = F.silu(hidden_ref).contiguous()
+
+tensor_diff("silu_hidden", matSilu_ref, matSilu)
+
+# Second GEMM tensors
+#
+# res = matSilu @ matD.t()
+# matSilu: M x N
+# matD:    N_out x N
+# res:     M x N_out
+
+N_out = TileN * 8
+matD = torch.rand(N_out, N, dtype=dtype, device=gpu) - 0.5
+
+assert N_out % TileN == 0
+
+# For the second GEMM, the K dimension is the hidden dimension N.
+num_k_folds_second = N // TileK
+
+assert num_k_folds_second % tp_size == 0
+
+k_folds_per_rank = num_k_folds_second // tp_size
+K_shard = k_folds_per_rank * TileK
+
+n_tiles_second = N_out // TileN
+
+# Each TP rank computes a partial full output.
+matC_partials = [
+    torch.zeros(M, N_out, dtype=dtype, device=gpu)
+    for _ in range(tp_size)
+]
+
+torch.cuda.synchronize()
+
+# Second GEMM:
+# K-split / row-parallel
+#
+# Computes partials:
+# matC_partial_rank = matSilu[:, K_rank] @ matD[:, K_rank].t()
+#
+# Then:
+# res = manual_reduction(matC_partials)
+
+for tp_rank in range(tp_size):
+    rank_k_start_fold = tp_rank * k_folds_per_rank
+    BaseK = rank_k_start_fold * TileK
+
+    matC_partial = matC_partials[tp_rank]
+
+    for n_base_tile in range(0, n_tiles_second, n_chunk_tiles):
+        cur_n_tiles = min(n_chunk_tiles, n_tiles_second - n_base_tile)
+        N_chunk = cur_n_tiles * TileN
+        BaseN = n_base_tile * TileN
+
+        dae = Launcher(num_sms, device=gpu)
+
+        loadA = TmaTensor(dae, matSilu).wgmma_load(TileM, TileK, Major.K)
+        loadB = TmaTensor(dae, matD).wgmma_load(TileN, TileK * Atom.n_batch, Major.K)
+        reduceC = TmaTensor(dae, matC_partial).wgmma("reduce", TileM, TileN, Major.K)
+
+        gemm = ManualGemm(
+            Atom,
+            MNK=(M, N_chunk, K_shard),
+            tmas=(loadA, loadB, reduceC),
+            MNK_base=(0, BaseN, BaseK),
+            num_k_folds=k_folds_per_rank,
+        ).place(num_sms, base_sm=0)
+
+        dae.i(
+            gemm,
+            TerminateC(),
+            TerminateM(),
+        )
+
+        dae_app(dae)
+
+torch.cuda.synchronize()
+
+# Final partial-output sum using explicit CUDA reduction kernel
+assert tp_size == 2
+
+res = torch.zeros(M, N_out, dtype=dtype, device=gpu)
+
+assert matC_partials[0].is_contiguous()
+assert matC_partials[1].is_contiguous()
+assert res.is_contiguous()
+
+manual_reduction(
+    matC_partials[0],
+    matC_partials[1],
+    res,
+)
+
+torch.cuda.synchronize()
+
+# Optional sanity check against old PyTorch/Python sum
+res_sum = sum(matC_partials)
+tensor_diff("manual_reduction_vs_sum", res_sum, res)
+
+# Full PyTorch reference
+ref = F.silu(matA @ matB.t()) @ matD.t()
+
+tensor_diff("full_mlp", ref, res)

--- a/app/python/manual_sum.cu
+++ b/app/python/manual_sum.cu
@@ -1,0 +1,54 @@
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_bf16.h>
+
+
+__global__ void manual_reduction_kernel(const __nv_bfloat16* partial0, const __nv_bfloat16* partial1, __nv_bfloat16* output, int numel) {
+
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+
+    if (idx < numel) {
+        float a = __bfloat162float(partial0[idx]);
+        float b = __bfloat162float(partial1[idx]);
+        output[idx] = __float2bfloat16(a + b);
+    }
+}
+
+
+void manual_reduction(
+    torch::Tensor partial0,
+    torch::Tensor partial1,
+    torch::Tensor output
+) {
+    TORCH_CHECK(partial0.is_cuda(), "partial0 must be a CUDA tensor");
+    TORCH_CHECK(partial1.is_cuda(), "partial1 must be a CUDA tensor");
+    TORCH_CHECK(output.is_cuda(), "output must be a CUDA tensor");
+
+    TORCH_CHECK(partial0.dtype() == torch::kBFloat16, "partial0 must be BF16");
+    TORCH_CHECK(partial1.dtype() == torch::kBFloat16, "partial1 must be BF16");
+    TORCH_CHECK(output.dtype() == torch::kBFloat16, "output must be BF16");
+
+    TORCH_CHECK(partial0.numel() == partial1.numel(), "partials must have same numel");
+    TORCH_CHECK(partial0.numel() == output.numel(), "output must have same numel");
+
+    TORCH_CHECK(partial0.is_contiguous(), "partial0 must be contiguous");
+    TORCH_CHECK(partial1.is_contiguous(), "partial1 must be contiguous");
+    TORCH_CHECK(output.is_contiguous(), "output must be contiguous");
+
+    int numel = partial0.numel();
+
+    int threads = 256;
+    int blocks = (numel + threads - 1) / threads;
+
+    cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    manual_reduction_kernel<<<blocks, threads, 0, stream>>>(reinterpret_cast<const __nv_bfloat16*>(partial0.data_ptr<at::BFloat16>()), reinterpret_cast<const __nv_bfloat16*>(partial1.data_ptr<at::BFloat16>()), reinterpret_cast<__nv_bfloat16*>(output.data_ptr<at::BFloat16>()), numel);
+}
+
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("manual_reduction", &manual_reduction, "Manual BF16 partial-output reduction");
+}

--- a/app/python/manual_sum.py
+++ b/app/python/manual_sum.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+from torch.utils.cpp_extension import load
+
+_src_path = Path(__file__).with_name("manual_sum.cu")
+
+_manual_sum_ext = load(
+    name="manual_sum_ext",
+    sources=[str(_src_path)],
+    with_cuda=True,
+    verbose=True,
+)
+
+manual_reduction = _manual_sum_ext.manual_reduction


### PR DESCRIPTION
This PR adds an end-to-end tensor-parallel MLP correctness test on one GPU using virtual TP ranks.

The implemented pattern is:

- First GEMM: column-parallel / N-split across TP ranks
- Activation: local SiLU applied to the hidden output
- Second GEMM: row-parallel / K-split across TP ranks
- Final reduction: explicit CUDA BF16 reduction kernel over the partial outputs

Current correctness results:

```text
Ave Diff first_gemm_hidden: 0.0 %
Ave Diff silu_hidden: 0.0 %
Ave Diff manual_reduction_vs_sum: 0.0 %
Ave Diff full_mlp: 0.16724876140015538 %
```

The first GEMM and SiLU activation match the PyTorch BF16 reference exactly. The manual CUDA BF16 reduction also matches the previous PyTorch/Python sum of partial outputs exactly. The final full-MLP output differs from the PyTorch reference by about 0.167% average diff, which appears consistent with BF16 accumulation/order differences.

Benchmark/debug behavior is inherited from the existing project harness and is not addressed in this PR.

The benchmark output appears to report timings for each individual VDCores launch rather than one full end-to-end MLP run. With the current dimensions, one logical tensor-parallel MLP pass seems to involve 6 VDCores GEMM launches: 2 launches for the first column-parallel GEMM at about 68.6 µs each, followed by 4 launches for the second row-parallel GEMM at about 20.7 µs each. If these benchmark blocks correspond directly to the `dae_app(dae)` calls in the script, then summing one sequence gives roughly 220 µs of VDCores GEMM execution time for the current configuration. This should be interpreted cautiously, since the timing likely only covers the VDCores GEMM launch path and may not include additional MLP work such as activation, manual reduction, setup, or correctness checks.